### PR TITLE
Add a setting option "Skip break when running fullscreen apps"

### DIFF
--- a/eyes-thanks/src/dialog.cpp
+++ b/eyes-thanks/src/dialog.cpp
@@ -75,6 +75,7 @@ void Dialog::InitWidgets()
 
     CheckBox_Clock       = new QCheckBox();
     CheckBox_Message     = new QCheckBox();
+    CheckBox_FullScreen  = new QCheckBox();
     CheckBox_Logging     = new QCheckBox();
     CheckBox_PrettyFont  = new QCheckBox();
     CheckBox_Text        = new QCheckBox();
@@ -110,6 +111,7 @@ void Dialog::InitWidgets()
     layoutGrid_Tab1->addWidget(Label_BreakDuration,         2, 0);
     layoutGrid_Tab1->addWidget(Spinbox_BreakDuration, 2, 1);
     layoutGrid_Tab1->addWidget(CheckBox_Message,        3, 0, 1, 2);
+    layoutGrid_Tab1->addWidget(CheckBox_FullScreen,     4, 0, 1, 2);
 
     layoutGrid_Tab1->setColumnStretch(0, 2);
     layoutGrid_Tab1->setColumnStretch(1, 1);
@@ -269,6 +271,7 @@ void Dialog::InitConnectWidgetsChanged()
 
     connect(CheckBox_Clock,       SIGNAL(clicked()), this, SLOT(SaveButton_status()));
     connect(CheckBox_Message,     SIGNAL(clicked()), this, SLOT(SaveButton_status()));
+    connect(CheckBox_FullScreen,  SIGNAL(clicked()), this, SLOT(SaveButton_status()));
     connect(CheckBox_Logging,     SIGNAL(clicked()), this, SLOT(SaveButton_status()));
     connect(CheckBox_PrettyFont,  SIGNAL(clicked()), this, SLOT(SaveButton_status()));
     connect(CheckBox_Text,        SIGNAL(clicked()), this, SLOT(SaveButton_status()));
@@ -303,6 +306,7 @@ void Dialog::SaveButton_status()
         CheckBox_Text->isChecked(),
         CheckBox_Clock->isChecked(),
         CheckBox_Message->isChecked(),
+        CheckBox_FullScreen->isChecked(),
         CheckBox_PrettyFont->isChecked(),
         CheckBox_StartupLink->isChecked(),
         TextEdit_Text->toPlainText(),
@@ -347,6 +351,7 @@ void Dialog::Translate()
     Combobox_iconsMode->setItemText(2, tr("White"));
 
     CheckBox_Message->setText(tr("30-sec message"));
+    CheckBox_FullScreen->setText(tr("Skip break when running fullscreen apps"));
     CheckBox_Logging->setText(tr("Logging to .txt"));
     CheckBox_StartupLink->setText(tr("Run on Windows startup"));
 
@@ -429,6 +434,7 @@ void Dialog::SetValues(const Setting &setting)
     CheckBox_Text->setChecked(setting.isText);
     CheckBox_Clock->setChecked(setting.isClock);
     CheckBox_Message->setChecked(setting.isMessage30sec);
+    CheckBox_FullScreen->setChecked(setting.isSkipWhenFullScreen);
     CheckBox_PrettyFont->setChecked(setting.isPrettyFont);
     CheckBox_StartupLink->setChecked(setting.isStartupLink);
     TextEdit_Text->setEnabled(setting.isText);
@@ -513,6 +519,7 @@ void Dialog::SaveValues()
         CheckBox_Text->isChecked(),
         CheckBox_Clock->isChecked(),
         CheckBox_Message->isChecked(),
+        CheckBox_FullScreen->isChecked(),
         CheckBox_PrettyFont->isChecked(),
         CheckBox_StartupLink->isChecked(),
         TextEdit_Text->toPlainText(),

--- a/eyes-thanks/src/dialog.h
+++ b/eyes-thanks/src/dialog.h
@@ -91,6 +91,7 @@ private:
     QComboBox *Combobox_imageAspectMode{};
     QCheckBox *CheckBox_Clock{};
     QCheckBox *CheckBox_Message{};
+    QCheckBox *CheckBox_FullScreen {};
     QCheckBox *CheckBox_Logging{};
     QCheckBox *CheckBox_PrettyFont{};
     QCheckBox *CheckBox_Text{};

--- a/eyes-thanks/src/global.h
+++ b/eyes-thanks/src/global.h
@@ -27,6 +27,7 @@ struct Setting
     bool isText{};
     bool isClock{};
     bool isMessage30sec{};
+    bool isSkipWhenFullScreen{};
     bool isPrettyFont{};
     bool isStartupLink{};
     QString text{};
@@ -42,12 +43,12 @@ inline bool operator==(const Setting &lhs, const Setting &rhs)
 {
     return std::tie(lhs.running_counter, lhs.pauseInterval, lhs.pauseDuration, lhs.imagesPath,
                     lhs.imagesPathAlternative, lhs.imageAspectMode, lhs.iconsMode, lhs.isLogging, lhs.isText,
-                    lhs.isClock, lhs.isMessage30sec, lhs.isPrettyFont, lhs.isStartupLink, lhs.text, lhs.isSpectrum,
-                    lhs.isTiling, lhs.isStripes, lhs.isCircle, lhs.isCircles, lhs.isNeo)
+                    lhs.isClock, lhs.isMessage30sec, lhs.isSkipWhenFullScreen, lhs.isPrettyFont, lhs.isStartupLink,
+                    lhs.text, lhs.isSpectrum, lhs.isTiling, lhs.isStripes, lhs.isCircle, lhs.isCircles, lhs.isNeo)
             == std::tie(rhs.running_counter, rhs.pauseInterval, rhs.pauseDuration, rhs.imagesPath,
                         rhs.imagesPathAlternative, rhs.imageAspectMode, rhs.iconsMode, rhs.isLogging, rhs.isText,
-                        rhs.isClock, rhs.isMessage30sec, rhs.isPrettyFont, rhs.isStartupLink, rhs.text, rhs.isSpectrum,
-                        rhs.isTiling, rhs.isStripes, rhs.isCircle, rhs.isCircles, rhs.isNeo);
+                        rhs.isClock, rhs.isMessage30sec, rhs.isSkipWhenFullScreen, rhs.isPrettyFont, rhs.isStartupLink,
+                        rhs.text, rhs.isSpectrum, rhs.isTiling, rhs.isStripes, rhs.isCircle, rhs.isCircles, rhs.isNeo);
 }
 
 inline bool operator!=(const Setting &lhs, const Setting &rhs)

--- a/eyes-thanks/src/trayicon.cpp
+++ b/eyes-thanks/src/trayicon.cpp
@@ -179,6 +179,7 @@ void TrayIcon::readSettings()
 
     setting.isClock         = settings.value("clock_enabled", true).toBool();
     setting.isMessage30sec  = settings.value("message_enabled", true).toBool();
+    setting.isSkipWhenFullScreen = settings.value("skipWhenFullScreen_enabled", true).toBool();
     setting.isLogging       = settings.value("logging_enabled", false).toBool();
     setting.isText          = settings.value("text_enabled", false).toBool();
     setting.isPrettyFont    = settings.value("prettyFont_enabled", true).toBool();
@@ -278,6 +279,7 @@ void TrayIcon::writeSettings()
 
     qsettings.setValue("clock_enabled",          setting.isClock);
     qsettings.setValue("message_enabled",        setting.isMessage30sec);
+    qsettings.setValue("skipWhenFullScreen_enabled", setting.isSkipWhenFullScreen);
     qsettings.setValue("logging_enabled",        setting.isLogging);
     qsettings.setValue("prettyFont_enabled",     setting.isPrettyFont);
     qsettings.setValue("startupLink_enabled",    setting.isStartupLink);

--- a/eyes-thanks/src/view.h
+++ b/eyes-thanks/src/view.h
@@ -80,6 +80,8 @@ private:
     void SetPredeterminedBackground();
     QString SetImageBackground(qreal ratio_pic, QPixmap pic);
     void SaveSceneToFile(QString dir_path);
+    bool CheckIsForegroundFullScreen();
+
 
     const Rect default_screen;
     const Rect desktop;


### PR DESCRIPTION
Hi, I add a setting option for skipping eyes' break when running foreground fullscreen apps.

The files changed are formatted by the clang format style file provided in this project.